### PR TITLE
feat: support for selecting GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ venv/
 
 # written by setuptools_scm
 **/_version.py
+log.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "warpfield"
-version = "0.2.0"
+version = "0.2.1"
 description = "GPU-accelerated 3D non-rigid registration"
 authors = [
     { name = "jlab.berlin" },
@@ -18,7 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "scipy",
-    "cupy-cuda12x",
+    #"cupy-cuda12x",
     "tqdm",
     "pydantic",
     "pyyaml",

--- a/src/warpfield/__main__.py
+++ b/src/warpfield/__main__.py
@@ -27,6 +27,12 @@ def main():
     parser.add_argument(
         "--invert", action="store_true", help="Invert the warp map and register the moving image to the fixed image."
     )
+    parser.add_argument(
+        "--gpu_id",
+        type=int,
+        default=0,
+        help="GPU ID to use for the operation (default: 0).",
+    )
     args = parser.parse_args()
     output_path = args.output or f"{os.path.splitext(args.moving)[0]}_registered.h5"
 
@@ -45,7 +51,7 @@ def main():
 
     # register
     logging.info("Registering the moving image to the fixed image...")
-    registered_image, warp_map, _ = register_volumes(fixed_image, moving_image, recipe, verbose=True)
+    registered_image, warp_map, _ = register_volumes(fixed_image, moving_image, recipe, verbose=True,gpu_id=args.gpu_id)
 
     if args.invert:
         logging.info("Inverting the warp map...")

--- a/src/warpfield/__main__.py
+++ b/src/warpfield/__main__.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import h5py
 import hdf5plugin
+import cupy as cp
 
 from .utils import load_data
 from .register import register_volumes, Recipe
@@ -35,6 +36,8 @@ def main():
     )
     args = parser.parse_args()
     output_path = args.output or f"{os.path.splitext(args.moving)[0]}_registered.h5"
+
+    cp.cuda.Device(args.gpu_id).use()
 
     # load
     logging.info(f"Loading fixed image from {args.fixed}...")

--- a/src/warpfield/ndimage.py
+++ b/src/warpfield/ndimage.py
@@ -7,7 +7,7 @@ import cupyx.scipy.ndimage
 import cupyx.scipy.signal
 
 
-def dogfilter(vol, sigma_low=1, sigma_high=4, mode="reflect"):
+def dogfilter(vol, sigma_low=1, sigma_high=4, mode="reflect", gpu_id = 0):
     """Diffference of Gaussians filter
 
     Args:
@@ -15,6 +15,7 @@ def dogfilter(vol, sigma_low=1, sigma_high=4, mode="reflect"):
         sigma_low (scalar or sequence of scalar): standard deviations
         sigma_high (scalar or sequence of scalar): standard deviations
         mode (str): The array borders are handled according to the given mode
+        gpu_id (int): GPU ID to use for the operation
 
     Returns:
         (array_like): filtered data
@@ -23,57 +24,60 @@ def dogfilter(vol, sigma_low=1, sigma_high=4, mode="reflect"):
         cupyx.scipy.ndimage.gaussian_filter
         skimage.filters.difference_of_gaussians
     """
-    in_module = vol.__class__.__module__
-    vol = cp.array(vol, "float32", copy=False)
-    out = cupyx.scipy.ndimage.gaussian_filter(vol, sigma_low, mode=mode)
-    out -= cupyx.scipy.ndimage.gaussian_filter(vol, sigma_high, mode=mode)
-    if in_module == "numpy":
-        out = out.get()
-    return out
+    with cp.cuda.Device(gpu_id):
+        in_module = vol.__class__.__module__
+        vol = cp.array(vol, "float32", copy=False)
+        out = cupyx.scipy.ndimage.gaussian_filter(vol, sigma_low, mode=mode)
+        out -= cupyx.scipy.ndimage.gaussian_filter(vol, sigma_high, mode=mode)
+        if in_module == "numpy":
+            out = out.get()
+        return out
 
 
-def periodic_smooth_decomposition_nd_rfft(img):
+def periodic_smooth_decomposition_nd_rfft(img, gpu_id = 0):
     """
     Decompose ND arrays of 2D images into periodic plus smooth components. This can help with edge artifacts in
     Fourier transforms.
 
     Args:
         img (cupy.ndarray): input image or volume. The last two axes are treated as the image dimensions.
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         cupy.ndarray: periodic component
     """
-    # compute border-difference
-    B = cp.zeros_like(img)
-    B[..., 0, :] = img[..., -1, :] - img[..., 0, :]
-    B[..., -1, :] = -B[..., 0, :]
-    B[..., :, 0] += img[..., :, -1] - img[..., :, 0]
-    B[..., :, -1] -= img[..., :, -1] - img[..., :, 0]
+    with cp.cuda.Device(gpu_id):
+        # compute border-difference
+        B = cp.zeros_like(img)
+        B[..., 0, :] = img[..., -1, :] - img[..., 0, :]
+        B[..., -1, :] = -B[..., 0, :]
+        B[..., :, 0] += img[..., :, -1] - img[..., :, 0]
+        B[..., :, -1] -= img[..., :, -1] - img[..., :, 0]
 
-    # real FFT of border difference
-    B_rfft = cp.fft.rfftn(B, axes=(-2, -1))
-    del B
+        # real FFT of border difference
+        B_rfft = cp.fft.rfftn(B, axes=(-2, -1))
+        del B
 
-    # build denom for full grid then slice to half-spectrum
-    M, N = img.shape[-2:]
-    q = cp.arange(M, dtype="float32").reshape(M, 1)
-    r = cp.arange(N, dtype="float32").reshape(1, N)
-    denom_full = 2 * cp.cos(2 * np.pi * q / M) + 2 * cp.cos(2 * np.pi * r / N) - 4
-    # take only first N//2+1 columns
-    denom_half = denom_full[:, : (N // 2 + 1)]
-    denom_half[0, 0] = 1  # avoid divide by zero
+        # build denom for full grid then slice to half-spectrum
+        M, N = img.shape[-2:]
+        q = cp.arange(M, dtype="float32").reshape(M, 1)
+        r = cp.arange(N, dtype="float32").reshape(1, N)
+        denom_full = 2 * cp.cos(2 * np.pi * q / M) + 2 * cp.cos(2 * np.pi * r / N) - 4
+        # take only first N//2+1 columns
+        denom_half = denom_full[:, : (N // 2 + 1)]
+        denom_half[0, 0] = 1  # avoid divide by zero
 
-    # compute smooth in freq domain (half-spectrum)
-    B_rfft /= denom_half
-    B_rfft[..., 0, 0] = 0
+        # compute smooth in freq domain (half-spectrum)
+        B_rfft /= denom_half
+        B_rfft[..., 0, 0] = 0
 
-    # invert real FFT back to spatial
-    # smooth = cp.fft.irfftn(B_rfft, s=(M, N), axes=(-2, -1))
-    # periodic = img - smooth
-    tmp = cp.fft.irfftn(B_rfft, s=(M, N), axes=(-2, -1))
-    tmp *= -1
-    tmp += img
-    return tmp
+        # invert real FFT back to spatial
+        # smooth = cp.fft.irfftn(B_rfft, s=(M, N), axes=(-2, -1))
+        # periodic = img - smooth
+        tmp = cp.fft.irfftn(B_rfft, s=(M, N), axes=(-2, -1))
+        tmp *= -1
+        tmp += img
+        return tmp
 
 
 def gausswin(shape, sigma):
@@ -191,13 +195,14 @@ def infill_nans(arr, sigma=0.5, truncate=50, ignore_warning=True):
     return out
 
 
-def sliding_block(data, block_size=100, block_stride=1):
+def sliding_block(data, block_size=100, block_stride=1, gpu_id=0):
     """Create a sliding window/block view into the array with the given block shape and stride. The block slides across all dimensions of the array and extracts subsets of the array at all positions.
 
     Args:
         data (array_like): Array to create the sliding window view from
         block_size (int or tuple of int): Size of window over each axis that takes part in the sliding block
         block_stride (int or tuple of int): Stride of teh window along each axis
+        gpu_id (int): GPU ID to use for the operation
 
     Returns:
         view (ndarray): Sliding block view of the array.
@@ -207,17 +212,18 @@ def sliding_block(data, block_size=100, block_stride=1):
         numpy.lib.stride_tricks.as_strided
 
     """
-    block_stride *= np.ones(data.ndim, dtype="int")
-    block_size *= np.ones(data.ndim, dtype="int")
-    shape = np.r_[1 + (data.shape - block_size) // block_stride, block_size]
-    strides = np.r_[block_stride * data.strides, data.strides]
-    xp = cp.get_array_module(data)
-    out = xp.lib.stride_tricks.as_strided(data, shape, strides)
-    return out
+    with cp.cuda.Device(gpu_id):
+        block_stride *= np.ones(data.ndim, dtype="int")
+        block_size *= np.ones(data.ndim, dtype="int")
+        shape = np.r_[1 + (data.shape - block_size) // block_stride, block_size]
+        strides = np.r_[block_stride * data.strides, data.strides]
+        xp = cp.get_array_module(data)
+        out = xp.lib.stride_tricks.as_strided(data, shape, strides)
+        return out
 
 
 def upsampled_dft_rfftn(
-    data: cp.ndarray, upsampled_region_size, upsample_factor: int = 1, axis_offsets=None
+    data: cp.ndarray, upsampled_region_size, upsample_factor: int = 1, axis_offsets=None, gpu_id=0
 ) -> cp.ndarray:
     """
     Performs an upsampled inverse DFT on a small region around given offsets,
@@ -234,56 +240,58 @@ def upsampled_dft_rfftn(
         upsample_factor: The integer upsampling factor in each axis.
         axis_offsets: The center of the patch in original-pixel coordinates
             (off_y, off_x). If None, defaults to (0, 0).
+        gpu_id: GPU ID to use for the operation.
 
     Returns:
         A complex-valued array of shape (..., m, n) containing the
         upsampled inverse DFT patch.
     """
-    if data.ndim < 2:
-        raise ValueError("Input must have at least 2 dimensions")
-    *batch_shape, M, Nf = data.shape
-    # determine patch size
-    if isinstance(upsampled_region_size, int):
-        m, n = upsampled_region_size, upsampled_region_size
-    else:
-        m, n = upsampled_region_size
-    # full width of original image
-    N = (Nf - 1) * 2
+    with cp.cuda.Device(gpu_id):
+        if data.ndim < 2:
+            raise ValueError("Input must have at least 2 dimensions")
+        *batch_shape, M, Nf = data.shape
+        # determine patch size
+        if isinstance(upsampled_region_size, int):
+            m, n = upsampled_region_size, upsampled_region_size
+        else:
+            m, n = upsampled_region_size
+        # full width of original image
+        N = (Nf - 1) * 2
 
-    # default offset: origin
-    off_y, off_x = (0.0, 0.0) if axis_offsets is None else axis_offsets
+        # default offset: origin
+        off_y, off_x = (0.0, 0.0) if axis_offsets is None else axis_offsets
 
-    # reconstruct full complex FFT via Hermitian symmetry
-    full = cp.empty(batch_shape + [M, N], dtype=cp.complex64)
-    full[..., :Nf] = data
-    if Nf > 1:
-        tail = data[..., :, 1:-1]
-        full[..., Nf:] = tail[..., ::-1, ::-1].conj()
+        # reconstruct full complex FFT via Hermitian symmetry
+        full = cp.empty(batch_shape + [M, N], dtype=cp.complex64)
+        full[..., :Nf] = data
+        if Nf > 1:
+            tail = data[..., :, 1:-1]
+            full[..., Nf:] = tail[..., ::-1, ::-1].conj()
 
-    # frequency coordinates
-    fy = cp.fft.fftfreq(M)[None, :]  # shape (1, M)
-    fx = cp.fft.fftfreq(N)[None, :]  # shape (1, N)
+        # frequency coordinates
+        fy = cp.fft.fftfreq(M)[None, :]  # shape (1, M)
+        fx = cp.fft.fftfreq(N)[None, :]  # shape (1, N)
 
-    # sample coordinates around offsets
-    y_idx = cp.arange(m) - (m // 2)
-    x_idx = cp.arange(n) - (n // 2)
-    y_coords = off_y[:, None] + y_idx[None, :] / upsample_factor  # (B, m)
-    x_coords = off_x[:, None] + x_idx[None, :] / upsample_factor  # (B, n)
+        # sample coordinates around offsets
+        y_idx = cp.arange(m) - (m // 2)
+        x_idx = cp.arange(n) - (n // 2)
+        y_coords = off_y[:, None] + y_idx[None, :] / upsample_factor  # (B, m)
+        x_coords = off_x[:, None] + x_idx[None, :] / upsample_factor  # (B, n)
 
-    # Build small inverse‐DFT kernels
-    ky = cp.exp(2j * cp.pi * y_coords[:, :, None] * fy[None, :, :]).astype("complex64")
-    kx = cp.exp(2j * cp.pi * x_coords[:, :, None] * fx[None, :, :]).astype("complex64")
+        # Build small inverse‐DFT kernels
+        ky = cp.exp(2j * cp.pi * y_coords[:, :, None] * fy[None, :, :]).astype("complex64")
+        kx = cp.exp(2j * cp.pi * x_coords[:, :, None] * fx[None, :, :]).astype("complex64")
 
-    # First apply along y: (B,m,M) × (B,M,N) -> (B,m,N)
-    out1 = cp.einsum("b m M, b M N -> b m N", ky, full)
-    # Then along x: (B,m,N) × (B,n,N)ᵀ -> (B,m,n)
-    patch = cp.einsum("b m N, b n N -> b m n", out1, kx)
+        # First apply along y: (B,m,M) × (B,M,N) -> (B,m,N)
+        out1 = cp.einsum("b m M, b M N -> b m N", ky, full)
+        # Then along x: (B,m,N) × (B,n,N)ᵀ -> (B,m,n)
+        patch = cp.einsum("b m N, b n N -> b m n", out1, kx)
 
-    return patch.real.reshape(*batch_shape, m, n)
+        return patch.real.reshape(*batch_shape, m, n)
 
 
 def zoom_chop_pad(
-    arr, target_shape=None, scale=(1, 1, 1), soft_edge=(0, 0, 0), shift=(0, 0, 0), flip=(False, False, False), cval=0
+    arr, target_shape=None, scale=(1, 1, 1), soft_edge=(0, 0, 0), shift=(0, 0, 0), flip=(False, False, False), cval=0, gpu_id=0
 ):
     """Zooms, softens, flips, shifts, and pads/crops a 3D array to match the target shape.
 
@@ -297,71 +305,75 @@ def zoom_chop_pad(
         shift (tuple): Shifts for each axis, in voxels. Default: (0, 0, 0).
         flip (tuple of bool): Whether to flip each axis. Default: (False, False, False).
         cval (int, float): The value to use for padding. Default: 0.
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         np.ndarray or cp.ndarray: The transformed array. Dtype is float32.
     """
 
-    was_numpy = isinstance(arr, np.ndarray)
+    with cp.cuda.Device(gpu_id):
+        was_numpy = isinstance(arr, np.ndarray)
 
-    if target_shape is None:
-        target_shape = arr.shape
+        if target_shape is None:
+            target_shape = arr.shape
 
-    if any(s > 0 for s in soft_edge):
-        arr = cp.array(arr, dtype="float32", copy=True, order="C")
-        scaled_edge = np.array(soft_edge) / np.array(scale)
-        arr = soften_edges(arr, soft_edge=scaled_edge, copy=False)
-    else:
-        arr = cp.array(arr, dtype="float32", copy=False, order="C")
+        if any(s > 0 for s in soft_edge):
+            arr = cp.array(arr, dtype="float32", copy=True, order="C")
+            scaled_edge = np.array(soft_edge) / np.array(scale)
+            arr = soften_edges(arr, soft_edge=scaled_edge, copy=False)
+        else:
+            arr = cp.array(arr, dtype="float32", copy=False, order="C")
 
-    coords = cp.indices(target_shape, dtype=cp.float32)
-    for i in range(len(coords)):
-        coords[i] -= target_shape[i] / 2
-        coords[i] /= scale[i]
-        coords[i] += arr.shape[i] / 2
-        if flip[i]:
-            coords[i] *= -1
-            coords[i] += arr.shape[i] - 1
-        coords[i] -= shift[i]
-    result = cupyx.scipy.ndimage.map_coordinates(arr, coords, order=1, mode="constant", cval=cval)
+        coords = cp.indices(target_shape, dtype=cp.float32)
+        for i in range(len(coords)):
+            coords[i] -= target_shape[i] / 2
+            coords[i] /= scale[i]
+            coords[i] += arr.shape[i] / 2
+            if flip[i]:
+                coords[i] *= -1
+                coords[i] += arr.shape[i] - 1
+            coords[i] -= shift[i]
+        result = cupyx.scipy.ndimage.map_coordinates(arr, coords, order=1, mode="constant", cval=cval)
 
-    if was_numpy:
-        result = result.get()
-    return result
+        if was_numpy:
+            result = result.get()
+        return result
 
 
-def soften_edges(arr, soft_edge=(0, 0, 0), copy=True):
+def soften_edges(arr, soft_edge=(0, 0, 0), copy=True, gpu_id=0):
     """Apply a soft Tukey edge to the input array.
 
     Args:
         arr (np.ndarray or cp.ndarray): The input array
         soft_edge (tuple of int): The size of the soft edge (Tukey envelope) to be applied to the input array, in voxels. Default: (0, 0, 0).
         copy (bool): If True, a copy of the array is made. Default: True.
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         np.ndarray or cp.ndarray: The transformed array. Dtype is float32.
     """
-    was_numpy = isinstance(arr, np.ndarray)
-    input_dtype = arr.dtype
-    arr = cp.array(arr, dtype="float32", copy=copy)
-    if isinstance(soft_edge, int) or isinstance(soft_edge, float):
-        soft_edge = (soft_edge,) * arr.ndim
-    soft_edge = np.clip(soft_edge, 0, np.array(arr.shape) / 2)
+    with cp.cuda.Device(gpu_id):
+        was_numpy = isinstance(arr, np.ndarray)
+        input_dtype = arr.dtype
+        arr = cp.array(arr, dtype="float32", copy=copy)
+        if isinstance(soft_edge, int) or isinstance(soft_edge, float):
+            soft_edge = (soft_edge,) * arr.ndim
+        soft_edge = np.clip(soft_edge, 0, np.array(arr.shape) / 2)
 
-    for i in range(arr.ndim):
-        if soft_edge[i] > 0:
-            alpha = 2 * soft_edge[i] / arr.shape[i]
-            alpha = np.clip(alpha, 0, 1)
-            win = cupyx.scipy.signal.windows.tukey(arr.shape[i], alpha)
-            arr *= cp.moveaxis(win[:, None, None], 0, i)
+        for i in range(arr.ndim):
+            if soft_edge[i] > 0:
+                alpha = 2 * soft_edge[i] / arr.shape[i]
+                alpha = np.clip(alpha, 0, 1)
+                win = cupyx.scipy.signal.windows.tukey(arr.shape[i], alpha)
+                arr *= cp.moveaxis(win[:, None, None], 0, i)
 
-    arr = arr.astype(input_dtype, copy=False)
-    if was_numpy:
-        arr = arr.get()
-    return arr
+        arr = arr.astype(input_dtype, copy=False)
+        if was_numpy:
+            arr = arr.get()
+        return arr
 
 
-def zoom(arr, zoom_factors, order=1, mode="constant"):
+def zoom(arr, zoom_factors, order=1, mode="constant", gpu_id=0):
     """Zooms an array by given factors along each axis.
 
     Args:
@@ -369,19 +381,21 @@ def zoom(arr, zoom_factors, order=1, mode="constant"):
         zoom_factors (tuple of float): Zoom factors for each axis. Values greater than 1 result in a larger output array,
             while values less than 1 result in a smaller array. Divide the physical voxel size of the input array by these values to get the physical voxel size of the output array.
         order (int): The order of the spline interpolation. Default is 1 (linear).
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         np.ndarray or cp.ndarray: The zoomed array.
     """
-    was_numpy = isinstance(arr, np.ndarray)
-    arr = cp.array(arr, dtype="float32", copy=False, order="C")
-    out = cupyx.scipy.ndimage.zoom(arr, zoom_factors, order=order)
-    if was_numpy:
-        out = out.get()
-    return out
+    with cp.cuda.Device(gpu_id):
+        was_numpy = isinstance(arr, np.ndarray)
+        arr = cp.array(arr, dtype="float32", copy=False, order="C")
+        out = cupyx.scipy.ndimage.zoom(arr, zoom_factors, order=order)
+        if was_numpy:
+            out = out.get()
+        return out
 
 
-def match_volumes(fixed, fixed_res, moving, moving_res, order=1, soft_edge=(0, 0, 0), cval=0, res_method="fixed"):
+def match_volumes(fixed, fixed_res, moving, moving_res, order=1, soft_edge=(0, 0, 0), cval=0, res_method="fixed", gpu_id=0):
     """
     Rescale and pad the fixed and moving volumes so both have the same physical size and resolution.
 
@@ -398,6 +412,7 @@ def match_volumes(fixed, fixed_res, moving, moving_res, order=1, soft_edge=(0, 0
             "min": use the finest (smallest) resolution,
             "max": use the coarsest (largest) resolution,
             "mean": use the mean of fixed_res and moving_res.
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         fixed_out (ndarray): The fixed volume, rescaled and padded to the target resolution and physical size.
@@ -434,19 +449,19 @@ def match_volumes(fixed, fixed_res, moving, moving_res, order=1, soft_edge=(0, 0
     # Rescale fixed
     scale_fixed = fixed_res / target_res
     fixed_out = zoom_chop_pad(
-        fixed, target_shape=target_shape, scale=scale_fixed, soft_edge=soft_edge, cval=cval, order=order
+        fixed, target_shape=target_shape, scale=scale_fixed, soft_edge=soft_edge, cval=cval, order=order, gpu_id=gpu_id
     )
 
     # Rescale moving
     scale_moving = moving_res / target_res
     moving_out = zoom_chop_pad(
-        moving, target_shape=target_shape, scale=scale_moving, soft_edge=soft_edge, cval=cval, order=order
+        moving, target_shape=target_shape, scale=scale_moving, soft_edge=soft_edge, cval=cval, order=order, gpu_id=gpu_id
     )
 
     return fixed_out, moving_out, tuple(target_res)
 
 
-def richardson_lucy_generic(img, convolve_psf, correlate_psf=None, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None):
+def richardson_lucy_generic(img, convolve_psf, correlate_psf=None, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None, gpu_id=0):
     """Richardson-Lucy deconvolution using arbitrary convolution operations, with optional Biggs acceleration.
 
     Args:
@@ -456,42 +471,45 @@ def richardson_lucy_generic(img, convolve_psf, correlate_psf=None, num_iter=5, e
         num_iter (int): number of iterations. Default is 5.
         epsilon (float): small constant to prevent divide-by-zero. Default is 1e-3.
         beta (float): acceleration parameter. Default is 0.0 (no acceleration). Typically, beta is in the range [0, 0.5].
+        gpu_id (int): GPU ID to use for the operation.
 
     Returns:
         ndarray: deconvolved image
     """
-    epsilon = cp.float32(epsilon)
-    img = cp.array(img, dtype="float32", copy=False)
-    cp.clip(img, 0, None, out=img)
-    if num_iter < 1:
-        return img
-    if correlate_psf is None:
-        correlate_psf = convolve_psf
 
-    if initial_guess is not None:
-        assert initial_guess.shape == img.shape, "Initial guess must have the same shape as the input image."
-        img_decon = cp.array(initial_guess, dtype="float32", copy=False)
-        cp.clip(img_decon, 0, None, out=img_decon)
-    else:   
-        img_decon = img.copy()
-    img_decon += epsilon
+    with cp.cuda.Device(gpu_id):
+        epsilon = cp.float32(epsilon)
+        img = cp.array(img, dtype="float32", copy=False)
+        cp.clip(img, 0, None, out=img)
+        if num_iter < 1:
+            return img
+        if correlate_psf is None:
+            correlate_psf = convolve_psf
 
-    for i in range(num_iter):
-        img_decon *= correlate_psf(img / (convolve_psf(img_decon) + epsilon))
+        if initial_guess is not None:
+            assert initial_guess.shape == img.shape, "Initial guess must have the same shape as the input image."
+            img_decon = cp.array(initial_guess, dtype="float32", copy=False)
+            cp.clip(img_decon, 0, None, out=img_decon)
+        else:   
+            img_decon = img.copy()
+        img_decon += epsilon
 
-        if beta > 0:
-            if i == 0: 
-                img_decon_prev = img_decon.copy()
-            else:
-                img_decon_new = img_decon.copy()
-                img_decon += beta * (img_decon - img_decon_prev)
-                cp.clip(img_decon, epsilon, None, out=img_decon)
-                img_decon_prev = img_decon_new
-    
-    return img_decon
+        for i in range(num_iter):
+            img_decon *= correlate_psf(img / (convolve_psf(img_decon) + epsilon))
+
+            if beta > 0:
+                if i == 0: 
+                    img_decon_prev = img_decon.copy()
+                else:
+                    img_decon_new = img_decon.copy()
+                    img_decon += beta * (img_decon - img_decon_prev)
+                    cp.clip(img_decon, epsilon, None, out=img_decon)
+                    img_decon_prev = img_decon_new
+        
+        return img_decon
 
 
-def richardson_lucy_fft(img, psf, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None):
+def richardson_lucy_fft(img, psf, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None, gpu_id=0):
     """Richardson-Lucy deconvolution using FFT-based convolution and optional Biggs acceleration.
 
     Args:
@@ -500,31 +518,34 @@ def richardson_lucy_fft(img, psf, num_iter=5, epsilon=1e-3, beta=0.0, initial_gu
         num_iter (int): number of iterations
         epsilon (float): small constant to avoid divide-by-zero
         beta (float): Biggs acceleration parameter (0 = no acceleration)
+        gpu_id (int): GPU ID to use for the operation
 
     Returns:
         ndarray: deconvolved image
     """
-    psf = cp.array(psf, dtype="float32")
-    cp.clip(psf, 0, None, out=psf)
-    psf /= psf.sum()
 
-    shape = img.shape
-    psf_ft = cp.fft.rfftn(cp.fft.ifftshift(psf), s=shape)
-    psf_ft_conj = cp.conj(psf_ft)
+    with cp.cuda.Device(gpu_id):
+        psf = cp.array(psf, dtype="float32")
+        cp.clip(psf, 0, None, out=psf)
+        psf /= psf.sum()
 
-    def convolve(x):
-        return cp.fft.irfftn(cp.fft.rfftn(x, s=shape) * psf_ft, s=shape)
+        shape = img.shape
+        psf_ft = cp.fft.rfftn(cp.fft.ifftshift(psf), s=shape)
+        psf_ft_conj = cp.conj(psf_ft)
 
-    def correlate(x):
-        return cp.fft.irfftn(cp.fft.rfftn(x, s=shape) * psf_ft_conj, s=shape)
+        def convolve(x):
+            return cp.fft.irfftn(cp.fft.rfftn(x, s=shape) * psf_ft, s=shape)
 
-    out = richardson_lucy_generic(
-        img, convolve, correlate, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess
-    )
-    return out
+        def correlate(x):
+            return cp.fft.irfftn(cp.fft.rfftn(x, s=shape) * psf_ft_conj, s=shape)
+
+        out = richardson_lucy_generic(
+            img, convolve, correlate, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess, gpu_id=gpu_id
+        )
+        return out
 
 
-def richardson_lucy_gaussian(img, sigmas, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None):
+def richardson_lucy_gaussian(img, sigmas, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None, gpu_id=0):
     """Richardson-Lucy deconvolution using Gaussian convolution operations
 
     Args:
@@ -537,14 +558,15 @@ def richardson_lucy_gaussian(img, sigmas, num_iter=5, epsilon=1e-3, beta=0.0, in
     Returns:
         ndarray: deconvolved image
     """
-    conv_with_gauss = lambda x: cupyx.scipy.ndimage.gaussian_filter(x, sigmas)
-    out = richardson_lucy_generic(
-        img, conv_with_gauss, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess
-    )
-    return out
+    with cp.cuda.Device(gpu_id):
+        conv_with_gauss = lambda x: cupyx.scipy.ndimage.gaussian_filter(x, sigmas)
+        out = richardson_lucy_generic(
+            img, conv_with_gauss, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess, gpu_id=gpu_id
+        )
+        return out
 
 
-def richardson_lucy_gaussian_shear(img, sigmas, shear, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None):
+def richardson_lucy_gaussian_shear(img, sigmas, shear, num_iter=5, epsilon=1e-3, beta=0.0, initial_guess=None, gpu_id=0):
     """Richardson-Lucy deconvolution using a sheared Gaussian psf
 
     Args:
@@ -554,21 +576,23 @@ def richardson_lucy_gaussian_shear(img, sigmas, shear, num_iter=5, epsilon=1e-3,
         num_iter (int): number of iterations
         epsilon (float): small constant to prevent divide-by-zero
         beta (float): acceleration parameter (0 = no acceleration)
+        gpu_id (int): GPU ID to use for the operation
 
     Returns:
         ndarray: deconvolved image
     """
-    if shear == 0:
-        return richardson_lucy_gaussian(img, sigmas, num_iter)
+    with cp.cuda.Device(gpu_id):
+        if shear == 0:
+            return richardson_lucy_gaussian(img, sigmas, num_iter, gpu_id = gpu_id)
 
-    sigmas = np.array(sigmas)
-    gw = cp.array(gausskernel_sheared(sigmas, shear=shear, truncate=4), "float32")
-    gw01 = gw.sum(2)[:, :, None]
-    gw01 /= gw01.sum()
-    gw2 = gw.sum(axis=(0, 1))[None, None, :]
-    gw2 /= gw2.sum()
-    conv_shear = lambda vol: cupyx.scipy.ndimage.convolve(cupyx.scipy.ndimage.convolve(vol, gw01), gw2)
-    out = richardson_lucy_generic(
-        img, conv_shear, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess
-    )
-    return out
+        sigmas = np.array(sigmas)
+        gw = cp.array(gausskernel_sheared(sigmas, shear=shear, truncate=4), "float32")
+        gw01 = gw.sum(2)[:, :, None]
+        gw01 /= gw01.sum()
+        gw2 = gw.sum(axis=(0, 1))[None, None, :]
+        gw2 /= gw2.sum()
+        conv_shear = lambda vol: cupyx.scipy.ndimage.convolve(cupyx.scipy.ndimage.convolve(vol, gw01), gw2)
+        out = richardson_lucy_generic(
+            img, conv_shear, num_iter=num_iter, epsilon=epsilon, beta=beta, initial_guess=initial_guess, gpu_id=gpu_id
+        )
+        return out

--- a/src/warpfield/register.py
+++ b/src/warpfield/register.py
@@ -39,12 +39,13 @@ class WarpMap:
         mov_shape (tuple): shape of the moving volume
     """
 
-    def __init__(self, warp_field, block_size, block_stride, ref_shape, mov_shape):
+    def __init__(self, warp_field, block_size, block_stride, ref_shape, mov_shape, gpu_id=0):
         self.warp_field = cp.array(warp_field, dtype="float32")
         self.block_size = cp.array(block_size, dtype="float32")
         self.block_stride = cp.array(block_stride, dtype="float32")
         self.ref_shape = ref_shape
         self.mov_shape = mov_shape
+        self.gpu_id = gpu_id
 
     def warp(self, vol, out=None):
         """Apply the warp to a volume. Can be thought of as pulling the moving volume to the fixed volume space.
@@ -55,14 +56,15 @@ class WarpMap:
         Returns:
             cupy.array: warped volume
         """
-        if np.any(vol.shape != np.array(self.mov_shape)):
-            warnings.warn(f"Volume shape {vol.shape} does not match the expected shape {self.mov_shape}.")
-        if out is None:
-            out = cp.zeros(self.ref_shape, dtype="float32", order="C")
-        vol_out = warp_volume(
-            vol, self.warp_field, self.block_stride, cp.array(-self.block_size / self.block_stride / 2), out=out
-        )
-        return vol_out
+        with cp.cuda.Device(self.gpu_id):
+            if np.any(vol.shape != np.array(self.mov_shape)):
+                warnings.warn(f"Volume shape {vol.shape} does not match the expected shape {self.mov_shape}.")
+            if out is None:
+                out = cp.zeros(self.ref_shape, dtype="float32", order="C")
+            vol_out = warp_volume(
+                vol, self.warp_field, self.block_stride, cp.array(-self.block_size / self.block_stride / 2), out=out
+            )
+            return vol_out
 
     def apply(self, *args, **kwargs):
         """Alias of warp method"""
@@ -78,27 +80,28 @@ class WarpMap:
             WarpMap:
             numpy.array: affine tranformation coefficients
         """
-        if target is None:
-            warp_field_shape = self.warp_field.shape
-            block_size = self.block_size
-            block_stride = self.block_stride
-        else:
-            warp_field_shape = target["warp_field_shape"]
-            block_size = cp.array(target["block_size"]).astype("float32")
-            block_stride = cp.array(target["block_stride"]).astype("float32")
+        with cp.cuda.Device(self.gpu_id):
+            if target is None:
+                warp_field_shape = self.warp_field.shape
+                block_size = self.block_size
+                block_stride = self.block_stride
+            else:
+                warp_field_shape = target["warp_field_shape"]
+                block_size = cp.array(target["block_size"]).astype("float32")
+                block_stride = cp.array(target["block_stride"]).astype("float32")
 
-        ix = cp.indices(self.warp_field.shape[1:]).reshape(3, -1).T
-        ix = ix * self.block_stride + self.block_size / 2
-        M = cp.zeros(self.warp_field.shape[1:])
-        #M[1:-1, 1:-1, 1:-1] = 1
-        M[:,:,:] = 1
-        ixg = cp.where(M.flatten() > 0)[0]
-        a = cp.hstack([ix[ixg], cp.ones((len(ixg), 1))])
-        b = ix[ixg] + self.warp_field.reshape(3, -1).T[ixg]
-        coeff = cp.linalg.lstsq(a, b, rcond=None)[0]
-        ix_out = cp.indices(warp_field_shape[1:]).reshape(3, -1).T * block_stride + block_size / 2
-        linfit = ((ix_out @ (coeff[:3] - cp.eye(3))) + coeff[3]).T.reshape(warp_field_shape)
-        return WarpMap(linfit, block_size, block_stride, self.ref_shape, self.mov_shape), coeff
+            ix = cp.indices(self.warp_field.shape[1:]).reshape(3, -1).T
+            ix = ix * self.block_stride + self.block_size / 2
+            M = cp.zeros(self.warp_field.shape[1:])
+            #M[1:-1, 1:-1, 1:-1] = 1
+            M[:,:,:] = 1
+            ixg = cp.where(M.flatten() > 0)[0]
+            a = cp.hstack([ix[ixg], cp.ones((len(ixg), 1))])
+            b = ix[ixg] + self.warp_field.reshape(3, -1).T[ixg]
+            coeff = cp.linalg.lstsq(a, b, rcond=None)[0]
+            ix_out = cp.indices(warp_field_shape[1:]).reshape(3, -1).T * block_stride + block_size / 2
+            linfit = ((ix_out @ (coeff[:3] - cp.eye(3))) + coeff[3]).T.reshape(warp_field_shape)
+            return WarpMap(linfit, block_size, block_stride, self.ref_shape, self.mov_shape), coeff
 
     def median_filter(self):
         """Apply median filter to the displacement field
@@ -106,8 +109,9 @@ class WarpMap:
         Returns:
             WarpMap: new WarpMap with median filtered displacement field
         """
-        warp_field = cupyx.scipy.ndimage.median_filter(self.warp_field, size=[1, 3, 3, 3], mode="nearest")
-        return WarpMap(warp_field, self.block_size, self.block_stride, self.ref_shape, self.mov_shape)
+        with cp.cuda.Device(self.gpu_id):
+            warp_field = cupyx.scipy.ndimage.median_filter(self.warp_field, size=[1, 3, 3, 3], mode="nearest")
+            return WarpMap(warp_field, self.block_size, self.block_stride, self.ref_shape, self.mov_shape)
 
     def resize_to(self, target):
         """Resize to target WarpMap, using linear interpolation
@@ -119,30 +123,32 @@ class WarpMap:
         Returns:
             WarpMap: resized WarpMap
         """
-        if isinstance(target, WarpMap):
-            t_sh, t_bsz, t_bst = target.warp_field.shape[1:], target.block_size, target.block_stride
-        elif isinstance(target, WarpMapper):
-            t_sh, t_bsz, t_bst = target.blocks_shape[:3], cp.array(target.block_size), cp.array(target.block_stride)
-        elif isinstance(target, dict):
-            t_sh, t_bsz, t_bst = (
-                target["warp_field_shape"][1:],
-                cp.array(target["block_size"]),
-                cp.array(target["block_stride"]),
-            )
-        else:
-            raise ValueError("target must be a WarpMap, WarpMapper, or dict")
-        ix = cp.array(cp.indices(t_sh).reshape(3, -1))
-        # ix = (ix + 0.5) / cp.array(self.block_size / t_bsz)[:, None] - 0.5
-        ix = (ix * t_bst[:, None] + (t_bsz - self.block_size)[:, None] / 2) / self.block_stride[:, None]
-        dm_r = cp.array(
-            [
-                cupyx.scipy.ndimage.map_coordinates(cp.array(self.warp_field[i]), ix, mode="nearest", order=1).reshape(
-                    t_sh
+
+        with cp.cuda.Device(self.gpu_id):
+            if isinstance(target, WarpMap):
+                t_sh, t_bsz, t_bst = target.warp_field.shape[1:], target.block_size, target.block_stride
+            elif isinstance(target, WarpMapper):
+                t_sh, t_bsz, t_bst = target.blocks_shape[:3], cp.array(target.block_size), cp.array(target.block_stride)
+            elif isinstance(target, dict):
+                t_sh, t_bsz, t_bst = (
+                    target["warp_field_shape"][1:],
+                    cp.array(target["block_size"]),
+                    cp.array(target["block_stride"]),
                 )
-                for i in range(3)
-            ]
-        )
-        return WarpMap(dm_r, t_bsz, t_bst, self.ref_shape, self.mov_shape)
+            else:
+                raise ValueError("target must be a WarpMap, WarpMapper, or dict")
+            ix = cp.array(cp.indices(t_sh).reshape(3, -1))
+            # ix = (ix + 0.5) / cp.array(self.block_size / t_bsz)[:, None] - 0.5
+            ix = (ix * t_bst[:, None] + (t_bsz - self.block_size)[:, None] / 2) / self.block_stride[:, None]
+            dm_r = cp.array(
+                [
+                    cupyx.scipy.ndimage.map_coordinates(cp.array(self.warp_field[i]), ix, mode="nearest", order=1).reshape(
+                        t_sh
+                    )
+                    for i in range(3)
+                ]
+            )
+            return WarpMap(dm_r, t_bsz, t_bst, self.ref_shape, self.mov_shape)
 
     def chain(self, target):
         """Chain displacement maps
@@ -153,10 +159,11 @@ class WarpMap:
         Returns:
             WarpMap: new WarpMap with chained displacement field
         """
-        indices = cp.indices(target.warp_field.shape[1:])
-        warp_field = self.warp_field.copy()
-        warp_field += target.warp_field
-        return WarpMap(warp_field, target.block_size, target.block_stride, self.ref_shape, self.mov_shape)
+        with cp.cuda.Device(self.gpu_id):
+            indices = cp.indices(target.warp_field.shape[1:])
+            warp_field = self.warp_field.copy()
+            warp_field += target.warp_field
+            return WarpMap(warp_field, target.block_size, target.block_stride, self.ref_shape, self.mov_shape)
 
     def invert(self, **kwargs):
         """alias for invert_fast method"""
@@ -194,19 +201,20 @@ class WarpMap:
         Returns:
             numpy.array: transformed voxel coordinates
         """
-        assert coords.shape[0] == 3
-        coords = cp.array(coords, dtype="float32")
-        # coords_blocked = coords / self.block_size[:, None] - 0.5
-        coords_blocked = coords / self.block_stride[:, None] - (self.block_size / (2 * self.block_stride))[:, None]
-        warp_field = self.warp_field.copy()
-        shifts = cp.zeros_like(coords)
-        for idim in range(3):
-            shifts[idim] = cupyx.scipy.ndimage.map_coordinates(
-                warp_field[idim], coords_blocked, order=1, mode="nearest"
-            )
-        if negative_shifts:
-            shifts = -shifts
-        return coords + shifts
+        with cp.cuda.Device(self.gpu_id):
+            assert coords.shape[0] == 3
+            coords = cp.array(coords, dtype="float32")
+            # coords_blocked = coords / self.block_size[:, None] - 0.5
+            coords_blocked = coords / self.block_stride[:, None] - (self.block_size / (2 * self.block_stride))[:, None]
+            warp_field = self.warp_field.copy()
+            shifts = cp.zeros_like(coords)
+            for idim in range(3):
+                shifts[idim] = cupyx.scipy.ndimage.map_coordinates(
+                    warp_field[idim], coords_blocked, order=1, mode="nearest"
+                )
+            if negative_shifts:
+                shifts = -shifts
+            return coords + shifts
 
     def pull_coordinates(self, coords):
         """Pull voxel coordinates through the warp field. Involves inversion, followed by pushing coordinates.
@@ -229,15 +237,16 @@ class WarpMap:
         Returns:
             detJ: cp.ndarray of shape spatial
         """
-        scaling = cp.array(units_per_voxel, dtype="float32") * self.block_stride
-        coords = cp.indices(self.warp_field.shape[1:], dtype="float32") * scaling[:, None, None, None]
-        phi = coords + self.warp_field
-        J = cp.empty(self.warp_field.shape[1:] + (3, 3), dtype="float32")
-        for i in range(3):
-            grads = cp.gradient(phi[i], *scaling, edge_order=edge_order)
-            for j in range(3):
-                J[..., i, j] = grads[j]
-        return cp.linalg.det(J)
+        with cp.cuda.Device(self.gpu_id):
+            scaling = cp.array(units_per_voxel, dtype="float32") * self.block_stride
+            coords = cp.indices(self.warp_field.shape[1:], dtype="float32") * scaling[:, None, None, None]
+            phi = coords + self.warp_field
+            J = cp.empty(self.warp_field.shape[1:] + (3, 3), dtype="float32")
+            for i in range(3):
+                grads = cp.gradient(phi[i], *scaling, edge_order=edge_order)
+                for j in range(3):
+                    J[..., i, j] = grads[j]
+            return cp.linalg.det(J)
 
     def as_ants_image(self, voxel_size_um=1):
         """Convert to ANTsImage
@@ -284,43 +293,45 @@ class WarpMapper:
     """
 
     def __init__(
-        self, ref_vol, block_size, block_stride=None, proj_method=None, subpixel=4, epsilon=1e-6, tukey_alpha=0.5
+        self, ref_vol, block_size, block_stride=None, proj_method=None, subpixel=4, epsilon=1e-6, tukey_alpha=0.5, gpu_id=0
     ):
         self.proj_method = proj_method
         self.plan_rev = [None, None, None]
         self.subpixel = subpixel
         self.epsilon = epsilon
         self.tukey_alpha = tukey_alpha
+        self.gpu_id = gpu_id
         self.update_reference(ref_vol, block_size, block_stride)
         self.ref_shape = np.array(ref_vol.shape)
         if np.any(block_size > np.array(ref_vol.shape)):
             raise ValueError(f"Block size ({block_size}) must be smaller than the volume shape ({ref_vol.shape})")
 
     def update_reference(self, ref_vol, block_size, block_stride=None):
-        ft = lambda arr: cp.fft.rfftn(arr, axes=(-2, -1))
-        block_size = np.array(block_size)
-        block_stride = block_size if block_stride is None else np.array(block_stride)
-        ref_blocks = sliding_block(cp.array(ref_vol), block_size=block_size, block_stride=block_stride)
-        self.blocks_shape = ref_blocks.shape
-        ref_blocks_proj = [self.proj_method(ref_blocks, axis=iax) for iax in [-3, -2, -1]]
-        if self.tukey_alpha < 1:
-            ref_blocks_proj = [
-                ref_blocks_proj[i]
-                * cp.array(
-                    ndwindow(
-                        [1, 1, 1, *ref_blocks_proj[i].shape[-2:]], lambda n: scipy.signal.windows.tukey(n, alpha=0.5)
-                    )
-                ).astype("float32")
-                for i in range(3)
+        with cp.cuda.Device(self.gpu_id):
+            ft = lambda arr: cp.fft.rfftn(arr, axes=(-2, -1))
+            block_size = np.array(block_size)
+            block_stride = block_size if block_stride is None else np.array(block_stride)
+            ref_blocks = sliding_block(cp.array(ref_vol), block_size=block_size, block_stride=block_stride)
+            self.blocks_shape = ref_blocks.shape
+            ref_blocks_proj = [self.proj_method(ref_blocks, axis=iax) for iax in [-3, -2, -1]]
+            if self.tukey_alpha < 1:
+                ref_blocks_proj = [
+                    ref_blocks_proj[i]
+                    * cp.array(
+                        ndwindow(
+                            [1, 1, 1, *ref_blocks_proj[i].shape[-2:]], lambda n: scipy.signal.windows.tukey(n, alpha=0.5)
+                        )
+                    ).astype("float32")
+                    for i in range(3)
+                ]
+            self.plan_fwd = [
+                cupyx.scipy.fft.get_fft_plan(ref_blocks_proj[i], axes=(-2, -1), value_type="R2C") for i in range(3)
             ]
-        self.plan_fwd = [
-            cupyx.scipy.fft.get_fft_plan(ref_blocks_proj[i], axes=(-2, -1), value_type="R2C") for i in range(3)
-        ]
-        self.ref_blocks_proj_ft_conj = [
-            cupyx.scipy.fft.rfftn(ref_blocks_proj[i], axes=(-2, -1), plan=self.plan_fwd[i]).conj() for i in range(3)
-        ]
-        self.block_size = block_size
-        self.block_stride = block_stride
+            self.ref_blocks_proj_ft_conj = [
+                cupyx.scipy.fft.rfftn(ref_blocks_proj[i], axes=(-2, -1), plan=self.plan_fwd[i]).conj() for i in range(3)
+            ]
+            self.block_size = block_size
+            self.block_stride = block_stride
 
     def get_displacement(self, vol, smooth_func=None):
         """Estimate the displacement of vol with the reference volume, via piece-wise rigid cross-correlation with the pre-saved blocks.
@@ -332,53 +343,55 @@ class WarpMapper:
         Returns:
             WarpMap
         """
-        vol_blocks = sliding_block(vol, block_size=self.block_size, block_stride=self.block_stride)
-        vol_blocks_proj = [self.proj_method(vol_blocks, axis=iax) for iax in [-3, -2, -1]]
-        del vol_blocks
+        with cp.cuda.Device(self.gpu_id):
+            vol_blocks = sliding_block(vol, block_size=self.block_size, block_stride=self.block_stride,gpu_id=self.gpu_id)
+            vol_blocks_proj = [self.proj_method(vol_blocks, axis=iax) for iax in [-3, -2, -1]]
+            del vol_blocks
 
-        disp_field = []
-        for i in range(3):
-            R = (
-                cupyx.scipy.fft.rfftn(vol_blocks_proj[i], axes=(-2, -1), plan=self.plan_fwd[i])
-                * self.ref_blocks_proj_ft_conj[i]
+            disp_field = []
+            for i in range(3):
+                R = (
+                    cupyx.scipy.fft.rfftn(vol_blocks_proj[i], axes=(-2, -1), plan=self.plan_fwd[i])
+                    * self.ref_blocks_proj_ft_conj[i]
+                )
+                if self.plan_rev[i] is None:
+                    self.plan_rev[i] = cupyx.scipy.fft.get_fft_plan(R, axes=(-2, -1), value_type="C2R")
+                xcorr_proj = cp.fft.fftshift(cupyx.scipy.fft.irfftn(R, axes=(-2, -1), plan=self.plan_rev[i]), axes=(-2, -1))
+                if smooth_func is not None:
+                    xcorr_proj = smooth_func(xcorr_proj, self.block_size)
+                xcorr_proj[..., xcorr_proj.shape[-2] // 2, xcorr_proj.shape[-1] // 2] += self.epsilon
+
+                max_ix = cp.array(cp.unravel_index(cp.argmax(xcorr_proj, axis=(-2, -1)), xcorr_proj.shape[-2:]))
+                max_ix = max_ix - cp.array(xcorr_proj.shape[-2:])[:, None, None, None] // 2
+                del xcorr_proj
+                i0, j0 = max_ix.reshape(2, -1)
+                shifts = upsampled_dft_rfftn(
+                    R.reshape(-1, *R.shape[-2:]),
+                    upsampled_region_size=int(self.subpixel * 2 + 1),
+                    upsample_factor=self.subpixel,
+                    axis_offsets=(i0, j0),
+                    gpu_id=self.gpu_id
+                )
+                del R
+                max_sub = cp.array(cp.unravel_index(cp.argmax(shifts, axis=(-2, -1)), shifts.shape[-2:]))
+                max_sub = (
+                    max_sub.reshape(max_ix.shape) - cp.array(shifts.shape[-2:])[:, None, None, None] // 2
+                ) / self.subpixel
+                del shifts
+                disp_field.append(max_ix + max_sub)
+
+            disp_field = cp.array(disp_field)
+            disp_field = (
+                cp.array(
+                    [
+                        disp_field[1, 0] + disp_field[2, 0],
+                        disp_field[0, 0] + disp_field[2, 1],
+                        disp_field[0, 1] + disp_field[1, 1],
+                    ]
+                ).astype("float32")
+                / 2
             )
-            if self.plan_rev[i] is None:
-                self.plan_rev[i] = cupyx.scipy.fft.get_fft_plan(R, axes=(-2, -1), value_type="C2R")
-            xcorr_proj = cp.fft.fftshift(cupyx.scipy.fft.irfftn(R, axes=(-2, -1), plan=self.plan_rev[i]), axes=(-2, -1))
-            if smooth_func is not None:
-                xcorr_proj = smooth_func(xcorr_proj, self.block_size)
-            xcorr_proj[..., xcorr_proj.shape[-2] // 2, xcorr_proj.shape[-1] // 2] += self.epsilon
-
-            max_ix = cp.array(cp.unravel_index(cp.argmax(xcorr_proj, axis=(-2, -1)), xcorr_proj.shape[-2:]))
-            max_ix = max_ix - cp.array(xcorr_proj.shape[-2:])[:, None, None, None] // 2
-            del xcorr_proj
-            i0, j0 = max_ix.reshape(2, -1)
-            shifts = upsampled_dft_rfftn(
-                R.reshape(-1, *R.shape[-2:]),
-                upsampled_region_size=int(self.subpixel * 2 + 1),
-                upsample_factor=self.subpixel,
-                axis_offsets=(i0, j0),
-            )
-            del R
-            max_sub = cp.array(cp.unravel_index(cp.argmax(shifts, axis=(-2, -1)), shifts.shape[-2:]))
-            max_sub = (
-                max_sub.reshape(max_ix.shape) - cp.array(shifts.shape[-2:])[:, None, None, None] // 2
-            ) / self.subpixel
-            del shifts
-            disp_field.append(max_ix + max_sub)
-
-        disp_field = cp.array(disp_field)
-        disp_field = (
-            cp.array(
-                [
-                    disp_field[1, 0] + disp_field[2, 0],
-                    disp_field[0, 0] + disp_field[2, 1],
-                    disp_field[0, 1] + disp_field[1, 1],
-                ]
-            ).astype("float32")
-            / 2
-        )
-        return WarpMap(disp_field, self.block_size, self.block_stride, self.ref_shape, vol.shape)
+            return WarpMap(disp_field, self.block_size, self.block_stride, self.ref_shape, vol.shape)
 
 
 class RegistrationPyramid:
@@ -392,37 +405,42 @@ class RegistrationPyramid:
         clip_thresh (float): Threshold for clipping the reference volume
     """
 
-    def __init__(self, ref_vol, recipe, reg_mask=1):
+    def __init__(self, ref_vol, recipe, reg_mask=1,gpu_id=0):
+        
+        self.gpu_id = gpu_id
         recipe.model_validate(recipe.model_dump())
         self.recipe = recipe
-        self.reg_mask = cp.array(reg_mask, dtype="float32", copy=False, order="C")
-        self.mappers = []
-        ref_vol = cp.array(ref_vol, dtype="float32", copy=False, order="C")
-        self.ref_shape = ref_vol.shape
-        if self.recipe.pre_filter is not None:
-            ref_vol = self.recipe.pre_filter(ref_vol, reg_mask=self.reg_mask)
-        self.mapper_ix = []
-        for i in range(len(recipe.levels)):
-            if recipe.levels[i].repeats < 1:
-                continue
-            block_size = np.array(recipe.levels[i].block_size)
-            tmp = np.r_[ref_vol.shape] // -block_size
-            block_size[block_size < 0] = tmp[block_size < 0]
-            if isinstance(recipe.levels[i].block_stride, (int, float)):
-                block_stride = (block_size * recipe.levels[i].block_stride).astype("int")
-            else:
-                block_stride = np.array(recipe.levels[i].block_stride)
-            self.mappers.append(
-                WarpMapper(
-                    ref_vol,
-                    block_size,
-                    block_stride=block_stride,
-                    proj_method=recipe.levels[i].project,
-                    tukey_alpha=recipe.levels[i].tukey_ref,
+
+        with cp.cuda.Device(self.gpu_id):
+            self.reg_mask = cp.array(reg_mask, dtype="float32", copy=False, order="C")
+            self.mappers = []
+            ref_vol = cp.array(ref_vol, dtype="float32", copy=False, order="C")
+            self.ref_shape = ref_vol.shape
+            if self.recipe.pre_filter is not None:
+                ref_vol = self.recipe.pre_filter(ref_vol, reg_mask=self.reg_mask)
+            self.mapper_ix = []
+            for i in range(len(recipe.levels)):
+                if recipe.levels[i].repeats < 1:
+                    continue
+                block_size = np.array(recipe.levels[i].block_size)
+                tmp = np.r_[ref_vol.shape] // -block_size
+                block_size[block_size < 0] = tmp[block_size < 0]
+                if isinstance(recipe.levels[i].block_stride, (int, float)):
+                    block_stride = (block_size * recipe.levels[i].block_stride).astype("int")
+                else:
+                    block_stride = np.array(recipe.levels[i].block_stride)
+                self.mappers.append(
+                    WarpMapper(
+                        ref_vol,
+                        block_size,
+                        block_stride=block_stride,
+                        proj_method=recipe.levels[i].project,
+                        tukey_alpha=recipe.levels[i].tukey_ref,
+                        gpu_id=self.gpu_id
+                    )
                 )
-            )
-            self.mapper_ix.append(i)
-        assert len(self.mappers) > 0, "At least one level of registration is required"
+                self.mapper_ix.append(i)
+            assert len(self.mappers) > 0, "At least one level of registration is required"
 
     def register_single(self, vol, callback=None, verbose=False):
         """Register a single volume to the reference volume.
@@ -436,60 +454,61 @@ class RegistrationPyramid:
             - warp_map (WarpMap): Displacement field
             - callback_output (list): List of outputs from the callback function
         """
-        was_numpy = isinstance(vol, np.ndarray)
-        vol = cp.array(vol, "float32", copy=False, order="C")
-        offsets = (cp.array(vol.shape) - cp.array(self.ref_shape)) / 2
-        warp_map = WarpMap(offsets[:, None, None, None], cp.ones(3), cp.ones(3), self.ref_shape, vol.shape)
-        warp_map = warp_map.resize_to(self.mappers[-1])
-        callback_output = []
-        vol_tmp0 = self.recipe.pre_filter(vol, reg_mask=self.reg_mask) if self.recipe.pre_filter is not None else vol
-        vol_tmp = cp.zeros(self.ref_shape, dtype="float32", order="C")
-        warp_map.warp(vol_tmp0, out=vol_tmp)
-        min_block_stride = np.min([mapper.block_stride for mapper in self.mappers], axis=0)
-        if callback is not None:
-            callback_output.append(callback(vol_tmp))
+        with cp.cuda.Device(self.gpu_id):
+            was_numpy = isinstance(vol, np.ndarray)
+            vol = cp.array(vol, "float32", copy=False, order="C")
+            offsets = (cp.array(vol.shape) - cp.array(self.ref_shape)) / 2
+            warp_map = WarpMap(offsets[:, None, None, None], cp.ones(3), cp.ones(3), self.ref_shape, vol.shape,gpu_id=self.gpu_id)
+            warp_map = warp_map.resize_to(self.mappers[-1])
+            callback_output = []
+            vol_tmp0 = self.recipe.pre_filter(vol, reg_mask=self.reg_mask) if self.recipe.pre_filter is not None else vol
+            vol_tmp = cp.zeros(self.ref_shape, dtype="float32", order="C")
+            warp_map.warp(vol_tmp0, out=vol_tmp)
+            min_block_stride = np.min([mapper.block_stride for mapper in self.mappers], axis=0)
+            if callback is not None:
+                callback_output.append(callback(vol_tmp))
 
-        if np.any(self.mappers[-1].block_stride > min_block_stride[0]):
-            warnings.warn(
-                "The block stride (in voxels) in the last level should not be larger than the block stride in any previous level (along any axis)."
-            )
-        for k, mapper in enumerate(tqdm(self.mappers, desc=f"Levels", disable=not verbose)):
-            for _ in tqdm(
-                range(self.recipe.levels[self.mapper_ix[k]].repeats), leave=False, desc=f"Repeats", disable=not verbose
-            ):
-                wm = mapper.get_displacement(
-                    vol_tmp, smooth_func=self.recipe.levels[self.mapper_ix[k]].smooth  # * self.reg_mask,
+            if np.any(self.mappers[-1].block_stride > min_block_stride[0]):
+                warnings.warn(
+                    "The block stride (in voxels) in the last level should not be larger than the block stride in any previous level (along any axis)."
                 )
-                wm.warp_field *= self.recipe.levels[self.mapper_ix[k]].update_rate
-                if self.recipe.levels[self.mapper_ix[k]].median_filter:
-                    wm = wm.median_filter()
-                if self.recipe.levels[self.mapper_ix[k]].affine:
-                    if (np.array(mapper.blocks_shape[:3]) < 2).sum() > 1:
-                        raise ValueError(
-                            f"Affine fit needs at least two axes with at least 2 blocks! Volume shape: {self.ref_shape}; block size: {mapper.block_size}"
-                        )
-                    wm, _ = wm.fit_affine(
-                        target=dict(
-                            warp_field_shape=(3, *self.mappers[-1].blocks_shape[:3]),
-                            block_size=self.mappers[-1].block_size,
-                            block_stride=self.mappers[-1].block_stride,
-                        )
+            for k, mapper in enumerate(tqdm(self.mappers, desc=f"Levels", disable=not verbose)):
+                for _ in tqdm(
+                    range(self.recipe.levels[self.mapper_ix[k]].repeats), leave=False, desc=f"Repeats", disable=not verbose
+                ):
+                    wm = mapper.get_displacement(
+                        vol_tmp, smooth_func=self.recipe.levels[self.mapper_ix[k]].smooth  # * self.reg_mask,
                     )
-                else:
-                    wm = wm.resize_to(self.mappers[-1])
+                    wm.warp_field *= self.recipe.levels[self.mapper_ix[k]].update_rate
+                    if self.recipe.levels[self.mapper_ix[k]].median_filter:
+                        wm = wm.median_filter()
+                    if self.recipe.levels[self.mapper_ix[k]].affine:
+                        if (np.array(mapper.blocks_shape[:3]) < 2).sum() > 1:
+                            raise ValueError(
+                                f"Affine fit needs at least two axes with at least 2 blocks! Volume shape: {self.ref_shape}; block size: {mapper.block_size}"
+                            )
+                        wm, _ = wm.fit_affine(
+                            target=dict(
+                                warp_field_shape=(3, *self.mappers[-1].blocks_shape[:3]),
+                                block_size=self.mappers[-1].block_size,
+                                block_stride=self.mappers[-1].block_stride,
+                            )
+                        )
+                    else:
+                        wm = wm.resize_to(self.mappers[-1])
 
-                warp_map = warp_map.chain(wm)
-                warp_map.warp(vol_tmp0, out=vol_tmp)
-                if callback is not None:
-                    # callback_output.append(callback(warp_map.unwarp(vol)))
-                    callback_output.append(callback(vol_tmp))
-        warp_map.warp(vol, out=vol_tmp)
-        if was_numpy:
-            vol_tmp = vol_tmp.get()
-        return vol_tmp, warp_map, callback_output
+                    warp_map = warp_map.chain(wm)
+                    warp_map.warp(vol_tmp0, out=vol_tmp)
+                    if callback is not None:
+                        # callback_output.append(callback(warp_map.unwarp(vol)))
+                        callback_output.append(callback(vol_tmp))
+            warp_map.warp(vol, out=vol_tmp)
+            if was_numpy:
+                vol_tmp = vol_tmp.get()
+            return vol_tmp, warp_map, callback_output
 
 
-def register_volumes(ref, vol, recipe, reg_mask=1, callback=None, verbose=True, video_path=None, vmax=None):
+def register_volumes(ref, vol, recipe, reg_mask=1, callback=None, verbose=True, video_path=None, vmax=None, gpu_id=0):
     """Register a volume to a reference volume using a registration pyramid.
 
     Args:
@@ -504,28 +523,30 @@ def register_volumes(ref, vol, recipe, reg_mask=1, callback=None, verbose=True, 
         verbose (bool): If True, show progress bars. Default is True
         video_path (str): Save a video of the registration process, using callback outputs. The callback has to return 2D frames. Default is None.
         vmax (float): Maximum pixel value (to scale video brightness). If none, set to 99.9 percentile of pixel values.
+        gpu_id (int): GPU ID to use for the registration. Default is 0.
 
     Returns:
         - numpy.array or cupy.array (depending on vol input): Registered volume
         - WarpMap: Displacement field
         - list: List of outputs from the callback function
     """
-    recipe.model_validate(recipe.model_dump())
-    reg = RegistrationPyramid(ref, recipe, reg_mask=reg_mask)
-    registered_vol, warp_map, cbout = reg.register_single(vol, callback=callback, verbose=verbose)
-    del reg
-    gc.collect()
-    cp.fft.config.get_plan_cache().clear()
+    with cp.cuda.Device(gpu_id):
+        recipe.model_validate(recipe.model_dump())
+        reg = RegistrationPyramid(ref, recipe, reg_mask=reg_mask, gpu_id=gpu_id)
+        registered_vol, warp_map, cbout = reg.register_single(vol, callback=callback, verbose=verbose)
+        del reg
+        gc.collect()
+        cp.fft.config.get_plan_cache().clear()
 
-    if video_path is not None:
-        try:
-            assert cbout[0].ndim == 2, "Callback output must be a 2D array"
-            ref = callback(recipe.pre_filter(ref))
-            vmax = np.percentile(ref, 99.9).item() if vmax is None else vmax
-            create_rgb_video(video_path, ref / vmax, np.array(cbout) / vmax, fps=10)
-        except (ValueError, AssertionError) as e:
-            warnings.warn(f"Video generation failed with error: {e}")
-    return registered_vol, warp_map, cbout
+        if video_path is not None:
+            try:
+                assert cbout[0].ndim == 2, "Callback output must be a 2D array"
+                ref = callback(recipe.pre_filter(ref))
+                vmax = np.percentile(ref, 99.9).item() if vmax is None else vmax
+                create_rgb_video(video_path, ref / vmax, np.array(cbout) / vmax, fps=10, gpu_id=gpu_id)
+            except (ValueError, AssertionError) as e:
+                warnings.warn(f"Video generation failed with error: {e}")
+        return registered_vol, warp_map, cbout
 
 
 class Projector(BaseModel):
@@ -539,6 +560,7 @@ class Projector(BaseModel):
         high: the higher sigma value for the DoG filter. Default is 10.0
         tukey_env: if True, apply a Tukey window to the output. Default is False
         gauss_env: if True, apply a Gaussian window to the output. Default is False
+        gpu_id: GPU ID to use for the projection. Default is 0
     """
 
     max: bool = True
@@ -547,6 +569,7 @@ class Projector(BaseModel):
     low: Union[Union[int, float], List[Union[int, float]]] = 0.5
     high: Union[Union[int, float], List[Union[int, float]]] = 10.0
     periodic_smooth: bool = False
+    gpu_id: int = 0
 
     def __call__(self, vol_blocks, axis):
         """Apply a 2D projection and filters to a volume block
@@ -556,21 +579,22 @@ class Projector(BaseModel):
         Returns:
             cupy.array: Projected volume block (5D dataset, with the first 3 dimensions being blocks and the last 2 dimensions being 2D projections)
         """
-        if self.max:
-            out = vol_blocks.max(axis)
-        else:
-            out = vol_blocks.mean(axis)
-        if self.periodic_smooth:
-            out = periodic_smooth_decomposition_nd_rfft(out)
-        low = np.delete(np.r_[1,1,1] * self.low, axis)
-        high = np.delete(np.r_[1,1,1] * self.high, axis)
-        if self.dog:
-            out = dogfilter(out, [0, 0, 0, *low], [0, 0, 0, *high], mode="reflect")
-        elif not np.all(np.array(self.low) == 0):
-            out = cupyx.scipy.ndimage.gaussian_filter(out, [0, 0, 0, *low], mode="reflect", truncate=5.0)
-        if self.normalize > 0:
-            out /= cp.sqrt(cp.sum(out**2, axis=(-2, -1), keepdims=True)) ** self.normalize + 1e-9
-        return out
+        with cp.cuda.Device(self.gpu_id):
+            if self.max:
+                out = vol_blocks.max(axis)
+            else:
+                out = vol_blocks.mean(axis)
+            if self.periodic_smooth:
+                out = periodic_smooth_decomposition_nd_rfft(out,gpu_id=self.gpu_id)
+            low = np.delete(np.r_[1,1,1] * self.low, axis)
+            high = np.delete(np.r_[1,1,1] * self.high, axis)
+            if self.dog:
+                out = dogfilter(out, [0, 0, 0, *low], [0, 0, 0, *high], mode="reflect",gpu_id=self.gpu_id)
+            elif not np.all(np.array(self.low) == 0):
+                out = cupyx.scipy.ndimage.gaussian_filter(out, [0, 0, 0, *low], mode="reflect", truncate=5.0)
+            if self.normalize > 0:
+                out /= cp.sqrt(cp.sum(out**2, axis=(-2, -1), keepdims=True)) ** self.normalize + 1e-9
+            return out
 
 
 class Smoother(BaseModel):
@@ -580,11 +604,13 @@ class Smoother(BaseModel):
         truncate (float): truncate parameter for gaussian kernel. Default is 5.
         shear (float): shear parameter for gaussian kernel. Default is None.
         long_range_ratio (float): long range ratio for double gaussian kernel. Default is None.
+        gpu_id (int): GPU ID to use for the smoothing. Default is 0.
     """
 
     sigmas: Union[float, List[float]] = [1.0, 1.0, 1.0]
     shear: Union[float, None] = None
     long_range_ratio: Union[float, None] = 0.05
+    gpu_id: int = 0
 
     def __call__(self, xcorr_proj, block_size=None):
         """Apply a Gaussian filter to the cross-correlation data
@@ -594,30 +620,31 @@ class Smoother(BaseModel):
         Returns:
             cupy.array: smoothed cross-correlation volume
         """
-        truncate = 4.0
-        if self.sigmas is None:
-            return xcorr_proj
-        if self.shear is not None:
-            shear_blocks = self.shear * (block_size[1] / block_size[0])
-            gw = gausskernel_sheared(self.sigma[:2], shear_blocks, truncate=truncate)
-            gw = cp.array(gw[:, :, None, None, None])
-            xcorr_proj = cupyx.scipy.ndimage.convolve(xcorr_proj, gw, mode="constant")
-            xcorr_proj = cupyx.scipy.ndimage.gaussian_filter1d(
-                xcorr_proj, self.sigmas[2], axis=2, mode="constant", truncate=truncate
-            )
-        else:  # shear is None:
-            xcorr_proj = cupyx.scipy.ndimage.gaussian_filter(
-                xcorr_proj, [*self.sigmas, 0, 0], mode="constant", truncate=truncate
-            )
-        if self.long_range_ratio is not None:
-            xcorr_proj *= 1 - self.long_range_ratio
-            xcorr_proj += (
-                cupyx.scipy.ndimage.gaussian_filter(
-                    xcorr_proj, [*np.array(self.sigmas) * 5, 0, 0], mode="constant", truncate=truncate
+        with cp.cuda.Device(self.gpu_id):
+            truncate = 4.0
+            if self.sigmas is None:
+                return xcorr_proj
+            if self.shear is not None:
+                shear_blocks = self.shear * (block_size[1] / block_size[0])
+                gw = gausskernel_sheared(self.sigma[:2], shear_blocks, truncate=truncate)
+                gw = cp.array(gw[:, :, None, None, None])
+                xcorr_proj = cupyx.scipy.ndimage.convolve(xcorr_proj, gw, mode="constant")
+                xcorr_proj = cupyx.scipy.ndimage.gaussian_filter1d(
+                    xcorr_proj, self.sigmas[2], axis=2, mode="constant", truncate=truncate
                 )
-                * self.long_range_ratio
-            )
-        return xcorr_proj
+            else:  # shear is None:
+                xcorr_proj = cupyx.scipy.ndimage.gaussian_filter(
+                    xcorr_proj, [*self.sigmas, 0, 0], mode="constant", truncate=truncate
+                )
+            if self.long_range_ratio is not None:
+                xcorr_proj *= 1 - self.long_range_ratio
+                xcorr_proj += (
+                    cupyx.scipy.ndimage.gaussian_filter(
+                        xcorr_proj, [*np.array(self.sigmas) * 5, 0, 0], mode="constant", truncate=truncate
+                    )
+                    * self.long_range_ratio
+                )
+            return xcorr_proj
 
 
 class RegFilter(BaseModel):
@@ -628,6 +655,7 @@ class RegFilter(BaseModel):
         dog: if True, apply a DoG filter to the volume. Default is True
         low: the lower sigma value for the DoG filter. Default is 0.5
         high: the higher sigma value for the DoG filter. Default is 10.0
+        gpu_id: GPU ID to use for the filter. Default is 0
     """
 
     clip_thresh: float = 0
@@ -635,6 +663,7 @@ class RegFilter(BaseModel):
     low: float = 0.5
     high: float = 10.0
     soft_edge: Union[Union[int, float], List[Union[int, float]]] = 0.0
+    gpu_id: int = 0
 
     def __call__(self, vol, reg_mask=None):
         """Apply the filter to the volume
@@ -644,14 +673,15 @@ class RegFilter(BaseModel):
         Returns:
             cupy.ndarray: Filtered volume
         """
-        vol = cp.clip(cp.array(vol, "float32", copy=False) - self.clip_thresh, 0, None)
-        if np.any(np.array(self.soft_edge) > 0):
-            vol = soften_edges(vol, soft_edge=self.soft_edge, copy=False)
-        if reg_mask is not None:
-            vol *= cp.array(reg_mask, dtype="float32", copy=False)
-        if self.dog:
-            vol = dogfilter(vol, self.low, self.high, mode="reflect")
-        return vol
+        with cp.cuda.Device(self.gpu_id):
+            vol = cp.clip(cp.array(vol, "float32", copy=False) - self.clip_thresh, 0, None)
+            if np.any(np.array(self.soft_edge) > 0):
+                vol = soften_edges(vol, soft_edge=self.soft_edge, copy=False)
+            if reg_mask is not None:
+                vol *= cp.array(reg_mask, dtype="float32", copy=False)
+            if self.dog:
+                vol = dogfilter(vol, self.low, self.high, mode="reflect")
+            return vol
 
 
 class LevelConfig(BaseModel):

--- a/src/warpfield/warp.py
+++ b/src/warpfield/warp.py
@@ -1,147 +1,113 @@
 import numpy as np
 import cupy as cp
 
-
-_warp_volume_kernel = cp.RawKernel(
-    r"""
-
+_warp_volume_kernel_code = r"""
 __device__ int ravel3d(const int * shape, const int i, const int j, const int k){
-    return i * shape[1]*shape[2] + j * shape[2] + k;
+    return i*shape[1]*shape[2] + j*shape[2] + k;
 }
-
-// Extrapolation modes
 #define EXTRAP_NEAREST 0
 #define EXTRAP_ZERO    1
 #define EXTRAP_LINEAR  2
-
 __device__ float trilinear_interp(const float* arr, const int* shape,
                                   float x, float y, float z, int mode)
 {
-    // Clip to extended range [-1, shape] to limit extrapolation
-    x = fminf(fmaxf(x,-1.0f), (float)shape[0]);
-    y = fminf(fmaxf(y,-1.0f), (float)shape[1]);
-    z = fminf(fmaxf(z,-1.0f), (float)shape[2]);
-
-    int x0 = __float2int_rd(x);
-    int y0 = __float2int_rd(y);
-    int z0 = __float2int_rd(z);
-    int x1 = x0 + 1;
-    int y1 = y0 + 1;
-    int z1 = z0 + 1;
-    float xd = x - (float)x0;  // now in [0, 1] when x in [x0, x0+1]
-    float yd = y - (float)y0;
-    float zd = z - (float)z0;
-
-    // Flattened 3D index
-    auto ravel3d = [](const int* shape, int x, int y, int z) {
-        return (x * shape[1] + y) * shape[2] + z;
-    };
-
-    // Inline voxel sampling with extrapolation
-    auto fetch = [&](int xi, int yi, int zi) -> float {
-        if (xi >= 0 && xi < shape[0] && yi >= 0 && yi < shape[1] && zi >= 0 && zi < shape[2])
-            return arr[ravel3d(shape, xi, yi, zi)];
-        if (mode == EXTRAP_ZERO) return 0.0f;
-        if (mode == EXTRAP_NEAREST) {
-            xi = max(0, min(shape[0]-1, xi));
-            yi = max(0, min(shape[1]-1, yi));
-            zi = max(0, min(shape[2]-1, zi));
-            return arr[ravel3d(shape, xi, yi, zi)];
+    x = fminf(fmaxf(x,-1.0f),(float)shape[0]);
+    y = fminf(fmaxf(y,-1.0f),(float)shape[1]);
+    z = fminf(fmaxf(z,-1.0f),(float)shape[2]);
+    int x0=__float2int_rd(x), y0=__float2int_rd(y), z0=__float2int_rd(z);
+    int x1=x0+1, y1=y0+1, z1=z0+1;
+    float xd=x-(float)x0, yd=y-(float)y0, zd=z-(float)z0;
+    auto r3 = [&](int xi,int yi,int zi){return (xi*shape[1]+yi)*shape[2]+zi;};
+    auto fetch = [&](int xi,int yi,int zi){
+        if(0<=xi&&xi<shape[0]&&0<=yi&&yi<shape[1]&&0<=zi&&zi<shape[2])
+            return arr[r3(xi,yi,zi)];
+        if(mode==EXTRAP_ZERO) return 0.0f;
+        if(mode==EXTRAP_NEAREST){
+            xi=max(0,min(shape[0]-1,xi));
+            yi=max(0,min(shape[1]-1,yi));
+            zi=max(0,min(shape[2]-1,zi));
+            return arr[r3(xi,yi,zi)];
         }
-        if (mode == EXTRAP_LINEAR) {
-            int xc = max(0, min(shape[0]-1, xi));
-            int xn = (xi < 0) ? xc + 1 : (xi >= shape[0]) ? xc - 1 : xc;
-            int yc = max(0, min(shape[1]-1, yi));
-            int yn = (yi < 0) ? yc + 1 : (yi >= shape[1]) ? yc - 1 : yc;
-            int zc = max(0, min(shape[2]-1, zi));
-            int zn = (zi < 0) ? zc + 1 : (zi >= shape[2]) ? zc - 1 : zc;
-            float v0 = arr[ravel3d(shape, xc, yc, zc)];
-            float v1 = arr[ravel3d(shape, xn, yn, zn)];
-            return v0 + (v0 - v1);  // linear extrapolation
-        }
-        return 0.0f;
+        int xc=max(0,min(shape[0]-1,xi)),
+            xn=(xi<0)?xc+1:(xi>=shape[0])?xc-1:xc;
+        int yc=max(0,min(shape[1]-1,yi)),
+            yn=(yi<0)?yc+1:(yi>=shape[1])?yc-1:yc;
+        int zc=max(0,min(shape[2]-1,zi)),
+            zn=(zi<0)?zc+1:(zi>=shape[2])?zc-1:zc;
+        float v0=arr[r3(xc,yc,zc)], v1=arr[r3(xn,yn,zn)];
+        return v0+(v0-v1);
     };
-
-    // Trilinear interpolation
-    float c00 = fetch(x0, y0, z0) * (1 - xd) + fetch(x1, y0, z0) * xd;
-    float c01 = fetch(x0, y0, z1) * (1 - xd) + fetch(x1, y0, z1) * xd;
-    float c10 = fetch(x0, y1, z0) * (1 - xd) + fetch(x1, y1, z0) * xd;
-    float c11 = fetch(x0, y1, z1) * (1 - xd) + fetch(x1, y1, z1) * xd;
-
-    float c0 = c00 * (1 - yd) + c10 * yd;
-    float c1 = c01 * (1 - yd) + c11 * yd;
-
-    return c0 * (1 - zd) + c1 * zd;
+    float c00=fetch(x0,y0,z0)*(1-xd)+fetch(x1,y0,z0)*xd;
+    float c01=fetch(x0,y0,z1)*(1-xd)+fetch(x1,y0,z1)*xd;
+    float c10=fetch(x0,y1,z0)*(1-xd)+fetch(x1,y1,z0)*xd;
+    float c11=fetch(x0,y1,z1)*(1-xd)+fetch(x1,y1,z1)*xd;
+    float c0=c00*(1-yd)+c10*yd;
+    float c1=c01*(1-yd)+c11*yd;
+    return c0*(1-zd)+c1*zd;
 }
-
-
-extern "C" __global__ void warp_volume_kernel(const float * arr, const int * arr_shape, const float * disp_field0, const float * disp_field1, const float * disp_field2, const int * disp_field_shape, const float * disp_scale, const float * disp_offset, float * out, const int * out_shape) {
-    float x,y,z,d0,d1,d2;
-    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < out_shape[0]; i += blockDim.x * gridDim.x) {
-        for (int j = blockIdx.y * blockDim.y + threadIdx.y; j < out_shape[1]; j += blockDim.y * gridDim.y) {
-            for (int k = blockIdx.z * blockDim.z + threadIdx.z; k < out_shape[2]; k += blockDim.z * gridDim.z) {
-                x = (float)i/disp_scale[0]+disp_offset[0];
-                y = (float)j/disp_scale[1]+disp_offset[1];
-                z = (float)k/disp_scale[2]+disp_offset[2];
-                d0 = trilinear_interp(disp_field0, disp_field_shape, x, y, z, EXTRAP_LINEAR);
-                d1 = trilinear_interp(disp_field1, disp_field_shape, x, y, z, EXTRAP_LINEAR);
-                d2 = trilinear_interp(disp_field2, disp_field_shape, x, y, z, EXTRAP_LINEAR);
-                int idx = ravel3d(out_shape, i,j,k);
-                out[idx] = trilinear_interp(arr, arr_shape, (float)i+d0, (float)j+d1, (float)k+d2, EXTRAP_ZERO);
-            }
-        }
+extern "C" __global__ void warp_volume_kernel(
+    const float* arr, const int* arr_shape,
+    const float* disp0,const float* disp1,const float* disp2,
+    const int* disp_shape,const float* scale,const float* offset,
+    float* out,const int* out_shape)
+{
+    for(int i=blockIdx.x*blockDim.x+threadIdx.x; i<out_shape[0]; i+=blockDim.x*gridDim.x)
+    for(int j=blockIdx.y*blockDim.y+threadIdx.y; j<out_shape[1]; j+=blockDim.y*gridDim.y)
+    for(int k=blockIdx.z*blockDim.z+threadIdx.z; k<out_shape[2]; k+=blockDim.z*gridDim.z)
+    {
+        float x=(float)i/scale[0]+offset[0],
+              y=(float)j/scale[1]+offset[1],
+              z=(float)k/scale[2]+offset[2];
+        float d0=trilinear_interp(disp0,disp_shape,x,y,z,EXTRAP_LINEAR);
+        float d1=trilinear_interp(disp1,disp_shape,x,y,z,EXTRAP_LINEAR);
+        float d2=trilinear_interp(disp2,disp_shape,x,y,z,EXTRAP_LINEAR);
+        int idx = ravel3d(out_shape,i,j,k);
+        out[idx]=trilinear_interp(
+            arr,arr_shape,
+            (float)i+d0,(float)j+d1,(float)k+d2,
+            EXTRAP_ZERO
+        );
     }
 }
-""",
-    "warp_volume_kernel",
-)
+"""
 
+_warp_volume_kernels = {}
 
-def warp_volume(vol, disp_field, disp_scale, disp_offset, out=None, tpb=[8, 8, 8],gpu_id=0):
-    """Warp a 3D volume using a displacement field (calling a CUDA kernel).
+def _get_warp_kernel(gpu_id):
+    if gpu_id not in _warp_volume_kernels:
+        with cp.cuda.Device(gpu_id):
+            _warp_volume_kernels[gpu_id] = cp.RawKernel(
+                _warp_volume_kernel_code, "warp_volume_kernel"
+            )
+    return _warp_volume_kernels[gpu_id]
 
-    This function applies a displacement field, typically obtained from a
-    registration algorithm, to warp a 3D volume. The displacement field
-    is a 4D array of shape (3, x, y, z), where the first dimension corresponds
-    to the x, y, and z displacements. It defines, for each voxel in the target
-    volume, the source location in the warped volume.
-
-    Args:
-        vol (array_like): 3D input array (x-y-z) to be warped.
-        disp_field (array_like): 4D array (3-x-y-z) of displacements along x, y, z.
-        disp_scale (array_like): Scaling factors for the displacement field.
-        disp_offset (array_like): Offset values for the displacement field.
-        out (array_like, optional): Output array to store the warped volume.
-            If None, a new array is created.
-        tpb (list, optional): Threads per block for CUDA kernel execution.
-            Defaults to [8, 8, 8].
-
-    Returns:
-        array_like: Warped 3D volume.
-    """
+def warp_volume(vol, disp_field, disp_scale, disp_offset,
+                out=None, tpb=[8,8,8], gpu_id=0):
     with cp.cuda.Device(gpu_id):
-        was_numpy = isinstance(vol, np.ndarray)
-        vol = cp.array(vol, dtype="float32", copy=False, order="C")
+        was_np = isinstance(vol, np.ndarray)
+        vol    = cp.array(vol, dtype="float32", copy=False, order="C")
+        df0    = cp.array(disp_field[0], dtype="float32", copy=False)
+        df1    = cp.array(disp_field[1], dtype="float32", copy=False)
+        df2    = cp.array(disp_field[2], dtype="float32", copy=False)
+        scale  = cp.array(disp_scale, dtype="float32", copy=False)
+        offset = cp.array(disp_offset, dtype="float32", copy=False)
+
         if out is None:
-            out = cp.zeros(vol.shape, dtype=vol.dtype)
-        assert out.dtype == cp.dtype("float32")
-        bpg = np.ceil(np.array(out.shape) / tpb).astype("int").tolist()  # blocks per grid
-        _warp_volume_kernel(
-            tuple(bpg),
-            tuple(tpb),
-            (
-                vol,
-                cp.r_[vol.shape].astype("int32"),
-                disp_field[0].astype("float32"),
-                disp_field[1].astype("float32"),
-                disp_field[2].astype("float32"),
-                cp.r_[disp_field.shape[1:]].astype("int32"),
-                disp_scale.astype("float32"),
-                disp_offset.astype("float32"),
-                out,
-                cp.r_[out.shape].astype("int32"),
-            ),
+            out = cp.zeros(vol.shape, dtype="float32", order="C")
+        else:
+            out = cp.array(out, dtype="float32", copy=False, order="C")
+
+        arr_shape  = cp.r_[vol.shape].astype("int32")
+        disp_shape = cp.r_[disp_field.shape[1:]].astype("int32")
+        out_shape  = cp.r_[out.shape].astype("int32")
+        bpg = np.ceil(np.array(out.shape)/tpb).astype("int").tolist()
+
+        kernel = _get_warp_kernel(gpu_id)
+        kernel(
+            tuple(bpg), tuple(tpb),
+            (vol, arr_shape, df0, df1, df2,
+             disp_shape, scale, offset,
+             out, out_shape)
         )
-        if was_numpy:
-            out = cp.asnumpy(out)
-        return out
+
+        return cp.asnumpy(out) if was_np else out

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -17,8 +17,9 @@ from warpfield.utils import load_data
 try:
     import cupy as cp
 
-    _ = cp.cuda.runtime.getDeviceCount()  # Check if any GPU devices are available
+    num_gpus = cp.cuda.runtime.getDeviceCount()  # Check if any GPU devices are available
     gpu_available = True
+    gpu_id = 0
 except (ImportError, cp.cuda.runtime.CUDARuntimeError):
     gpu_available = False
     warnings.warn("No GPU detected. Skipping GPU tests.")
@@ -81,7 +82,7 @@ def test_register_volumes():
     moving = np.roll(fixed, shift=5, axis=0).copy()  # Simulate a simple shift
     recipe = warpfield.Recipe.from_yaml("default.yml")
 
-    registered, warp_map, _ = warpfield.register_volumes(fixed, moving, recipe, verbose=False)
+    registered, warp_map, _ = warpfield.register_volumes(fixed, moving, recipe, verbose=False,gpu_id=gpu_id)
 
     assert registered.shape == fixed.shape, "Registered volume shape mismatch."
     assert (
@@ -122,6 +123,8 @@ def test_cli(tmp_path):
             recipe_path,
             "--output",
             str(output_path),
+            "--gpu_id",
+            str(gpu_id) 
         ],
         capture_output=True,
         text=True,

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -19,7 +19,7 @@ try:
 
     num_gpus = cp.cuda.runtime.getDeviceCount()  # Check if any GPU devices are available
     gpu_available = True
-    gpu_id = 0
+    gpu_ids = list(range(num_gpus))
 except (ImportError, cp.cuda.runtime.CUDARuntimeError):
     gpu_available = False
     warnings.warn("No GPU detected. Skipping GPU tests.")
@@ -76,7 +76,8 @@ def test_import_tiff(tmp_path):
 
 
 @pytest.mark.skipif(not gpu_available, reason="No GPU detected.")
-def test_register_volumes():
+@pytest.mark.parametrize("gpu_id", gpu_ids)
+def test_register_volumes(gpu_id):
     """Test the register_volumes function."""
     fixed = np.random.rand(256, 256, 256).astype("float32")
     moving = np.roll(fixed, shift=5, axis=0).copy()  # Simulate a simple shift
@@ -92,7 +93,8 @@ def test_register_volumes():
 
 
 @pytest.mark.skipif(not gpu_available, reason="No GPU detected.")
-def test_cli(tmp_path):
+@pytest.mark.parametrize("gpu_id", gpu_ids)
+def test_cli(tmp_path,gpu_id):
     """Test the CLI for registering volumes."""
     fixed = np.random.rand(256, 256, 256).astype("float32")
     moving = np.roll(fixed, shift=5, axis=0).copy()  # Simulate a simple shift


### PR DESCRIPTION
This PR introduces a new parameter `gpu_id` to any function that uses the GPU, sets the GPU that cupy should use, and guards computations with context managers. If the user does not provide `gpu_id`, it defaults to the first gpu that cupy recognizes.

We did have to make a few changes to the formatting (not actual code) of the CUDA kernel to get the tests to pass, but I want to double check that is really necessary, as we don't have this problem with our deconvolution library that also uses custom kernels and allows for GPU selection.

There is a test failing, but it also fails on main. I opened an issue about that. I'll mark this as a draft until the test gets fixed and I double check the kernel formatting.