### PR TITLE
fix block size check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "warpfield"
-version = "0.2.1"
+version = "0.2.2"
 description = "GPU-accelerated 3D non-rigid registration"
 authors = [
     { name = "jlab.berlin" },

--- a/src/warpfield/register.py
+++ b/src/warpfield/register.py
@@ -331,6 +331,8 @@ class WarpMapper:
     def __init__(
         self, ref_vol, block_size, block_stride=None, proj_method=None, subpixel=4, epsilon=1e-6, tukey_alpha=0.5
     ):
+        if np.any(block_size > np.array(ref_vol.shape)):
+            raise ValueError(f"Block size (currently: {block_size}) must be smaller than the volume shape ({np.array(ref_vol.shape)}).")
         self.proj_method = proj_method
         self.plan_rev = [None, None, None]
         self.subpixel = subpixel
@@ -338,8 +340,6 @@ class WarpMapper:
         self.tukey_alpha = tukey_alpha
         self.update_reference(ref_vol, block_size, block_stride)
         self.ref_shape = np.array(ref_vol.shape)
-        if np.any(block_size > np.array(ref_vol.shape)):
-            raise ValueError(f"Block size ({block_size}) must be smaller than the volume shape ({ref_vol.shape})")
 
     def update_reference(self, ref_vol, block_size, block_stride=None):
         ft = lambda arr: cp.fft.rfftn(arr, axes=(-2, -1))


### PR DESCRIPTION
This pull request introduces a version bump and improves input validation for the `WarpMapper` class constructor. The most important changes are:

Input validation:

* Moved and clarified the input validation for `block_size` in the `WarpMapper` constructor to ensure that the block size does not exceed the reference volume shape, raising a clear `ValueError` if the condition is violated.

Closes #28 