### PR TITLE
Simplify cupy installation in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         python-version: ["3.12"]
-        cupy-version: ["13.6"]
 
     defaults:
       run:
@@ -62,7 +61,7 @@ jobs:
 
       - name: Install package
         run: |
-          pip install "cupy-cuda12x==${{ matrix.cupy-version }}"
+          pip install cupy-cuda12x
           pip install -e .
 
       # this runs the platform-specific tests declared in tox.ini


### PR DESCRIPTION
Removed cupy-version matrix variable and updated installation command.